### PR TITLE
Adds a policy to mitigate CVE-2020-8554 by restricting public IPs

### DIFF
--- a/k8sExternalIPs_constraint.yaml
+++ b/k8sExternalIPs_constraint.yaml
@@ -1,0 +1,12 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sExternalIPs
+metadata:
+  name: external-ips
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Service"]
+  parameters:
+    allowedIPs:
+      - "203.0.113.0"


### PR DESCRIPTION
See https://groups.google.com/g/kubernetes-announce/c/GPpZzVtGwiI for more information on this vulnerability.