### PR TITLE
Add example blocking by CIDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ The [security advisory for this issue](https://groups.google.com/g/kubernetes-an
 This repository contains a Template and Constraint that restrict Services to a specific allow list of public IPs, thus limiting the ability of an attacker to add IPs outside of trusted values.
 
 You can apply these policies using [Policy Controller](https://cloud.google.com/anthos-config-management/docs/concepts/policy-controller), which is included as part of [Anthos Config Management](https://cloud.google.com/anthos/config-management). To customize the allowed IP addresses, edit or add items to the "allowedIPs" list in [k8sExternalIPs_constraint.yaml](https://github.com/jrmurray000/CVE-2020-8554/blob/main/k8sExternalIPs_constraint.yaml).
+
+## Blocking by CIDR
+
+
+If you just want to prevent an IP in a specific CIDR range use the files `k8sExternalIPsCIDR_constraint.yaml` and `k8sExternalIPsCIDR_template.yaml`. For example, if you want to prevent an attacker from specifying the `spec.externalIPs` field to the default Kubernetes Services CIDR.

--- a/k8sExternalIPsCIDR_constraint.yaml
+++ b/k8sExternalIPsCIDR_constraint.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sExternalIPs
+metadata:
+  name: external-ips
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+    - apiGroups:
+      - ""
+      kinds:
+      - Service
+    labelSelector:
+      matchExpressions: []
+    namespaceSelector:
+      labelSelector: []
+  parameters:
+    forbiddenCIDRs:
+    - 10.43.0.0/16
+    - 10.33.0.0/16

--- a/k8sExternalIPsCIDR_template.yaml
+++ b/k8sExternalIPsCIDR_template.yaml
@@ -1,0 +1,34 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sexternalips
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sExternalIPs
+      validation:
+        openAPIV3Schema:
+          properties:
+            forbiddenCIDRs:
+              items:
+                type: string
+              type: array
+  targets:
+  - rego: |
+      package k8sexternalips
+
+      violation[{"msg": msg}] {
+        input.review.kind.kind == "Service"
+        input.review.kind.group == ""
+
+        # turns list into a SET
+        forbiddenCIDRs := {ip | ip := input.parameters.forbiddenCIDRs[_]}
+        externalIPs := {ip | ip := input.review.object.spec.externalIPs[_]}
+        # check if ip contains in forbidden cidr range
+        forbiddenIPs := net.cidr_contains_matches(forbiddenCIDRs, externalIPs)
+        count(forbiddenIPs) > 0
+        msg := sprintf("Service has forbidden external IPs: %v in forbidden CIDR range: %v", [forbiddenIPs[_][1], forbiddenCIDRs])
+      }
+    target: admission.k8s.gatekeeper.sh
+


### PR DESCRIPTION
We wanted to prevent people from intercepting via a specific CIDR range rather than allowing specific IPs since we have a shared cluster and an unknown amount of allowed IPs.